### PR TITLE
[cssom] Fix a typo in "To serialize a LOCAL"

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -259,7 +259,7 @@ string, followed by "<code>)</code>".
 
 To <dfn export>serialize a LOCAL</dfn> means to create a string represented by
 "<code>local(</code>", followed by the
-<a lt="serialize a string">serialization</a> of the URL as a
+<a lt="serialize a string">serialization</a> of the LOCAL as a
 string, followed by "<code>)</code>".
 
 To <dfn export>serialize a comma-separated list</dfn> concatenate all items of


### PR DESCRIPTION
`s/URL/LOCAL/`. Looks like a simple copy/paste oversight from the "To serialize a URL" above.